### PR TITLE
fix(timer): デクリメント方式から終了時刻逆算方式に変更してタイマー精度を向上

### DIFF
--- a/components/timer/useTimer.ts
+++ b/components/timer/useTimer.ts
@@ -11,9 +11,11 @@ const SECONDS = 60;
 export const useTimer = (
   timerType: TimerType,
   autoStart: boolean = false,
-  onComplete?: () => void
+  onComplete?: () => void,
 ) => {
   const { settings } = useSettings();
+  const { sessionCount, maxSessions, incrementSession, resetSession } =
+  useSession();
   const { getSavedState, saveTimerState, clearTimerState } = useTimerState();
   const { playNotificationSound } = useNotificationSound();
 
@@ -29,20 +31,27 @@ export const useTimer = (
       default:
         return SECONDS * settings.focusTime;
     }
-  }, [timerType, settings.focusTime, settings.breakTime, settings.longBreakTime]);
+  }, [
+    timerType,
+    settings.focusTime,
+    settings.breakTime,
+    settings.longBreakTime,
+  ]);
 
-  // 保存された状態を取得
+  // ローカルストレージから保存されたタイマー状態を取得
   const savedState = getSavedState(timerType);
 
-  // 保存された状態があればそれを使用、なければ初期値
+  // 保存されたタイマー状態があればそれを使用、なければ初期値
   const [timeLeft, setTimeLeft] = useState(savedState?.timeLeft ?? initialTime);
   // autoStartがtrueの場合は自動でカウントダウンがスタートする
   const [isRunning, setIsRunning] = useState(savedState?.isRunning ?? autoStart);
   // 一度でもタイマーが開始されたかどうか（SETTINGS/RESET切り替え用）
   const [hasStarted, setHasStarted] = useState(savedState?.hasStarted ?? autoStart);
-
   // タイマー開始時刻を記録（作業記録用）
   const startTimeRef = useRef<Date | null>(savedState?.startTime ?? null);
+
+  // タイマー終了時刻を記録（作業記録用）
+  const endTimeRef = useRef<number | null>(null);
 
   // setIntervalのIDを保存するためのRef
   // useRefを使う理由：再レンダリングを引き起こさず、コンポーネントのライフサイクル全体で同じ値を保持できるため
@@ -51,13 +60,10 @@ export const useTimer = (
   // アンマウント時に最新の状態を保存するためのRef
   const stateRef = useRef({ timeLeft, isRunning, hasStarted });
 
-  const { sessionCount, maxSessions, incrementSession, resetSession } = useSession();
-
   // タイマーをスタート/停止する関数
   const toggleTimer = useCallback(() => {
     setIsRunning((prev) => {
       const newState = !prev;
-      console.log('current session count is', sessionCount);
       // タイマー開始時の処理
       if (newState) {
         // まだ開始時刻が記録されていない場合のみ現在時刻を記録
@@ -65,24 +71,31 @@ export const useTimer = (
           startTimeRef.current = new Date();
         }
 
+        // 終了時刻を計算（現在時刻 + 残り時間）
+        endTimeRef.current = Date.now() + timeLeft * 1000;
+
         // 一度でも開始したらhasStartedをtrueに
         setHasStarted(true);
+      } else {
+        // 一時停止時：終了時刻をクリア
+        endTimeRef.current = null;
       }
 
       return newState;
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const resetTimer = useCallback(() => {
     setIsRunning(false);
     setTimeLeft(initialTime);
     setHasStarted(false);
-
-    // リセット時は開始時刻もクリア
-    startTimeRef.current = null;
-
     // 保存された状態もクリア
     clearTimerState();
+
+    // リセット時は開始時刻と終了時刻をクリア
+    startTimeRef.current = null;
+    endTimeRef.current = null;
   }, [initialTime, clearTimerState]);
 
   // 最新の状態をrefに保存（アンマウント時に参照するため）
@@ -104,6 +117,7 @@ export const useTimer = (
     // マウント時：autoStart=true の場合、開始時刻を記録
     if (autoStart && !startTimeRef.current) {
       startTimeRef.current = new Date();
+      endTimeRef.current = Date.now() + timeLeft * 1000;
     }
 
     // マウント時：保存された状態から復元した場合、保存状態をクリア
@@ -130,63 +144,72 @@ export const useTimer = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 終了時刻逆算方式によるタイマーのカウントダウン処理
   useEffect(() => {
-    if (isRunning && timeLeft > 0) {
+    if (isRunning && endTimeRef.current) {
       intervalRef.current = setInterval(() => {
-        setTimeLeft((prev) => {
-          return prev - 1;
-        });
-      }, 1000);
-    } else if (isRunning && timeLeft === 0) {
-      setIsRunning(false);
+        const now = Date.now();
+        const remaining = Math.max(
+          0,
+          Math.ceil((endTimeRef.current! - now) / 1000),
+        );
 
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
+        setTimeLeft(remaining);
 
-      // タイマー完了時の処理
-      const handleTimerComplete = async () => {
-        // タイマーの状態をクリア
-        clearTimerState();
+        // 残り時間が0になった場合
+        if (remaining === 0) {
+          setIsRunning(false);
+          endTimeRef.current = null;
 
-        // focusタイマーの場合のみ作業記録を保存 & セッション数をインクリメント
-        if (timerType === 'focus' && startTimeRef.current) {
-          const endTime = new Date();
-          const durationMinutes = Math.floor(initialTime / 60);
-
-          try {
-            await createRecord({
-              startTime: startTimeRef.current,
-              endTime: endTime,
-              duration: durationMinutes,
-            });
-            console.log('作業記録を保存しました');
-            // セッション数をインクリメント
-            incrementSession();
-          } catch (error) {
-            console.error('作業記録の保存に失敗：', error);
-          } finally {
-            // 開始時刻をクリア
-            startTimeRef.current = null;
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
           }
-        } else if (timerType === 'long-break') {
-          // long-breakタイマー完了時はセッションをリセット
-          resetSession();
-        }
-      };
 
-      // 非同期処理を実行
-      handleTimerComplete()
-        .then(() => {
-          // 作業記録保存完了後、通知音を再生しつつ完了コールバックを呼び出す
-          playNotificationSound();
-          onComplete?.();
-        })
-        .catch((error) => {
-          console.error('予期しないエラー', error);
-          onComplete?.();
-        });
+          // タイマー完了時の処理
+          const handleTimerComplete = async () => {
+            // タイマーの状態をクリア
+            clearTimerState();
+
+            // focusタイマーの場合のみ作業記録を保存 & セッション数をインクリメント
+            if (timerType === 'focus' && startTimeRef.current) {
+              const endTime = new Date();
+              const durationMinutes = Math.floor(initialTime / 60);
+
+              try {
+                await createRecord({
+                  startTime: startTimeRef.current,
+                  endTime: endTime,
+                  duration: durationMinutes,
+                });
+                console.log('作業記録を保存しました');
+                // セッション数をインクリメント
+                incrementSession();
+              } catch (error) {
+                console.error('作業記録の保存に失敗：', error);
+              } finally {
+                // 開始時刻をクリア
+                startTimeRef.current = null;
+              }
+            } else if (timerType === 'long-break') {
+              // long-breakタイマー完了時はセッションをリセット
+              resetSession();
+            }
+          };
+
+          // 非同期処理を実行
+          handleTimerComplete()
+            .then(() => {
+              // 作業記録保存完了後、通知音を再生しつつ完了コールバックを呼び出す
+              playNotificationSound();
+              onComplete?.();
+            })
+            .catch((error) => {
+              console.error('予期しないエラー', error);
+              onComplete?.();
+            });
+        }
+      }, 250); // 250msごとに更新（より正確な計測のため）
     }
 
     return () => {
@@ -194,8 +217,16 @@ export const useTimer = (
         clearInterval(intervalRef.current);
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isRunning, timeLeft, timerType]);
+  }, [
+    isRunning,
+    timerType,
+    clearTimerState,
+    initialTime,
+    incrementSession,
+    resetSession,
+    playNotificationSound,
+    onComplete,
+  ]);
 
   return {
     sessionCount,


### PR DESCRIPTION
【問題】
バックグラウンドタブではsetIntervalが遅延し、1秒ごとのデクリメント方式では
計測ずれが発生していた

【解決策】
- タイマー開始時に終了予定時刻（endTime）を計算
- 250msごとに「終了時刻 - 現在時刻」で残り時間を逆算
- バックグラウンドから復帰しても正確な残り時間を表示

【変更内容】
- endTimeRef: useRefを追加（終了予定時刻を保存）
- カウントダウン処理: デクリメント → 逆算方式に変更
- 更新間隔: 1000ms → 250ms（より滑らかな表示）
- useEffect依存配列: eslint-disableを削除し適切に設定

Closes #5