### PR TITLE
fix: 他画面から復帰時にカウントダウンが停止する問題を修正

### DIFF
--- a/components/timer/TimerControls.tsx
+++ b/components/timer/TimerControls.tsx
@@ -20,7 +20,6 @@ export const TimerControls = memo(function TimerControls({
   onToggle,
   onReset,
 }: TimerControlsProps) {
-
   /**
    * 左ボタンを返す
    * - 未開始（hasStarted = false）: SETTINGSボタン（/settingsへ遷移）

--- a/components/timer/useTimer.ts
+++ b/components/timer/useTimer.ts
@@ -120,6 +120,11 @@ export const useTimer = (
       endTimeRef.current = Date.now() + timeLeft * 1000;
     }
 
+    // タイマーが実行中かつ終了時刻が記録されていない場合、終了時刻を計算
+    if (isRunning && !endTimeRef.current) {
+      endTimeRef.current = Date.now() + timeLeft * 1000;
+    }
+
     // マウント時：保存された状態から復元した場合、保存状態をクリア
     if (savedState) {
       clearTimerState();
@@ -182,7 +187,6 @@ export const useTimer = (
                   endTime: endTime,
                   duration: durationMinutes,
                 });
-                console.log('作業記録を保存しました');
                 // セッション数をインクリメント
                 incrementSession();
               } catch (error) {


### PR DESCRIPTION
画面遷移後にタイマー画面に戻ってきた際、タイマーが実行中であるにも
かかわらずカウントダウンが停止してしまう問題を修正。

useTimerフックの初期化処理で、isRunningがtrueだがendTimeRefが未設定の ケースを検出し、現在のtimeLeftから終了時刻を再計算することで、
画面復帰後も正常にカウントダウンが継続するように改善。

また、デバッグ用のconsole.logとコードフォーマットを整理。