### PR TITLE
fix(timer): toggleTimerの依存配列にtimeLeftを追加

### DIFF
--- a/components/timer/useTimer.ts
+++ b/components/timer/useTimer.ts
@@ -83,8 +83,7 @@ export const useTimer = (
 
       return newState;
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [timeLeft]);
 
   const resetTimer = useCallback(() => {
     setIsRunning(false);


### PR DESCRIPTION
STOP後に再開すると残り時間が初期値に戻る問題を修正。
useCallbackの依存配列が空だったためtimeLeftが古い値のまま
参照されていた。依存配列にtimeLeftを追加し、最新の残り時間で
終了時刻を計算するようにした。
Fixes #9